### PR TITLE
Update the report for  System GPU memory usage

### DIFF
--- a/docs/gpu/memory_usage/system_mem_usage.report
+++ b/docs/gpu/memory_usage/system_mem_usage.report
@@ -21,6 +21,8 @@ cudaLimit :
 	- cudaMallocHeapSize : default=8MB
 	- cudaLimitDevRuntimeSyncDepth : 1~24
 	- cudaLimitDevRuntimePendingLaunchCount : default=2048
+	- cudaLimitMaxL2FetchGranularity: 0~128
+	- cudaLimitPersistingL2CacheSize
 
 
 

--- a/docs/gpu/memory_usage/system_mem_usage.report
+++ b/docs/gpu/memory_usage/system_mem_usage.report
@@ -19,7 +19,7 @@ cudaLimit :
 	- cudaLimitStackSize : default=1024, min=16
 	- cudaLimitPrintfFifoSize 
 	- cudaMallocHeapSize : default=8MB
-	- cudaLimitDeviceRuntimeSyncDepth : 1~24
+	- cudaLimitDevRuntimeSyncDepth : 1~24
 	- cudaLimitDevRuntimePendingLaunchCount : default=2048
 
 


### PR DESCRIPTION
This PR fixes a typo on the document. It also adds two recent `cudaLimit` values, which are related to the L2 cache, if needed.