### PR TITLE
Fix `cudaLimitDeviceRuntimeSyncDepth` typo

### DIFF
--- a/docs/gpu/memory_usage/system_mem_usage.report
+++ b/docs/gpu/memory_usage/system_mem_usage.report
@@ -19,7 +19,7 @@ cudaLimit :
 	- cudaLimitStackSize : default=1024, min=16
 	- cudaLimitPrintfFifoSize 
 	- cudaMallocHeapSize : default=8MB
-	- cudaLimitDeviceRuntimeSyncDepth : 1~24
+	- cudaLimitDevRuntimeSyncDepth : 1~24
 	- cudaLimitDevRuntimePendingLaunchCount : default=2048
 
 


### PR DESCRIPTION
This PR replaces the `cudaLimitDeviceRuntimeSyncDepth` typo with`cudaLimitDevRuntimeSyncDepth`.

Reference: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html